### PR TITLE
Upgrade HexView to Avalonia 12.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
     - name: Build Release
       run: dotnet build --configuration Release
     - name: Test Release
@@ -39,7 +39,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
     - name: Pack NuGet Package
       run: dotnet pack src/HexView/HexView.csproj --configuration Release --output ./artifacts
     - name: Upload NuGet Artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
     - name: Extract version from tag
       id: version
       run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
@@ -42,7 +42,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
     - name: Push to NuGet
       run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 ﻿<Project>
   <PropertyGroup>
-    <AvaloniaVersion>11.3.12</AvaloniaVersion>
-    <ConsoloniaVersion>11.3.9-beta.2218</ConsoloniaVersion>
+    <AvaloniaVersion>12.0.0</AvaloniaVersion>
+    <ConsoloniaVersion>11.3.12.3</ConsoloniaVersion>
     <SystemTextJsonVersion>10.0.3</SystemTextJsonVersion>
-    <VersionPrefix>11.3.12</VersionPrefix>
+    <VersionPrefix>12.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -551,8 +551,9 @@ HexView uses a layered architecture for flexibility and performance:
 
 ## Requirements
 
-- .NET 9.0 or later
-- Avalonia 11.2 or later
+- .NET 8.0 or later for consuming the `HexView` package
+- .NET SDK 10.0.x for building this repository as configured
+- Avalonia 12.0.0
 
 ## Building from Source
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.201",
     "rollForward": "latestMinor",
     "allowPrerelease": true
   }

--- a/samples/HexView.Base/HexView.Base.csproj
+++ b/samples/HexView.Base/HexView.Base.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <IsPackable>false</IsPackable>

--- a/samples/HexView.Base/HexView.Base.csproj
+++ b/samples/HexView.Base/HexView.Base.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="ProDiagnostics" Version="$(AvaloniaVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\HexView\HexView.csproj" />

--- a/samples/HexView.Base/Views/SingleView.axaml
+++ b/samples/HexView.Base/Views/SingleView.axaml
@@ -234,7 +234,7 @@
                    VerticalAlignment="Center" HorizontalAlignment="Left" />
         <TextBox Name="PathTextBox" Grid.Column="2" BorderThickness="0"
                  Background="Transparent" VerticalAlignment="Center"
-                 Watermark="No file opened" FontSize="13" Padding="4,0" />
+                 PlaceholderText="No file opened" FontSize="13" Padding="4,0" />
         <Button Name="OpenButton" Click="OpenButton_OnClick"
                 Grid.Column="3" Classes="tool" MinWidth="95" Padding="12,6"
                 HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
@@ -299,7 +299,7 @@
           <Border Classes="card" Padding="7,7">
             <StackPanel Orientation="Horizontal" Spacing="6">
               <TextBox Name="AnnotationLabelTextBox" Width="180" Classes="search"
-                       Watermark="Annotation label" />
+                       PlaceholderText="Annotation label" />
               <Button Name="AddAnnotationButton" Click="AddAnnotationButton_OnClick"
                       Classes="tool" MinWidth="120" Padding="12,6"
                       HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
@@ -336,7 +336,7 @@
               </ComboBox.Items>
             </ComboBox>
             <TextBox Name="SearchTextBox" Width="320" Classes="search"
-                     Watermark="Search: 0x1234 or DE AD BE EF" />
+                     PlaceholderText="Search: 0x1234 or DE AD BE EF" />
             <Button Name="FindPrevButton" Click="FindPrevButton_OnClick"
                     Width="34" Height="30" Classes="tool" ToolTip.Tip="Previous (Shift+F3)"
                     HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
@@ -497,7 +497,7 @@
           <x:Int32>16</x:Int32>
         </ComboBox.Items>
       </ComboBox>
-      <CheckBox Name="ShowSepsCheckBox" IsChecked="True" Checked="ShowSepsCheckBox_OnChanged" Unchecked="ShowSepsCheckBox_OnChanged"/>
+      <CheckBox Name="ShowSepsCheckBox" IsChecked="True"/>
       <TextBox Name="AddrWidthTextBox" KeyUp="AddrWidthTextBox_OnKeyUp"/>
       <ComboBox Name="EncodingComboBox" SelectedIndex="0" SelectionChanged="EncodingComboBox_OnSelectionChanged">
         <ComboBox.Items>
@@ -507,7 +507,7 @@
           <x:String>UTF-16BE</x:String>
         </ComboBox.Items>
       </ComboBox>
-      <CheckBox Name="ControlGlyphCheckBox" IsChecked="True" Checked="ControlGlyphCheckBox_OnChanged" Unchecked="ControlGlyphCheckBox_OnChanged"/>
+      <CheckBox Name="ControlGlyphCheckBox" IsChecked="True"/>
       <TextBox Name="SelStartTextBox"/>
       <TextBox Name="SelLenTextBox"/>
       <TextBox Name="ReplaceTextBox"/>

--- a/samples/HexView.Base/Views/SingleView.axaml.cs
+++ b/samples/HexView.Base/Views/SingleView.axaml.cs
@@ -17,7 +17,6 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
-using Avalonia.VisualTree;
 using HexView.Avalonia.Model;
 using HexView.Avalonia.Services;
 
@@ -58,10 +57,12 @@ public partial class SingleView : UserControl
         {
             ShowSeparatorsMenuItem.IsChecked = ShowSepsCheckBox.IsChecked ?? false;
         };
+        ShowSepsCheckBox.IsCheckedChanged += ShowSepsCheckBox_OnChanged;
         ControlGlyphCheckBox.IsCheckedChanged += (s, e) =>
         {
             ShowControlGlyphMenuItem.IsChecked = ControlGlyphCheckBox.IsChecked ?? false;
         };
+        ControlGlyphCheckBox.IsCheckedChanged += ControlGlyphCheckBox_OnChanged;
 
         // Update bookmarks menu when opened
         BookmarksMenuItem.SubmenuOpened += BookmarksMenuItem_OnSubmenuOpened;
@@ -444,8 +445,7 @@ public partial class SingleView : UserControl
 
         if (Application.Current?.ApplicationLifetime is ISingleViewApplicationLifetime { MainView: { } mainView })
         {
-            var visualRoot = mainView.GetVisualRoot();
-            if (visualRoot is TopLevel topLevel)
+            if (TopLevel.GetTopLevel(mainView) is { } topLevel)
             {
                 return topLevel.StorageProvider;
             }

--- a/samples/HexView.Console/HexView.Console.csproj
+++ b/samples/HexView.Console/HexView.Console.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/samples/HexView.Desktop/HexView.Desktop.csproj
+++ b/samples/HexView.Desktop/HexView.Desktop.csproj
@@ -6,7 +6,7 @@
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TrimMode>full</TrimMode>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>

--- a/site/articles/getting-started/installation.md
+++ b/site/articles/getting-started/installation.md
@@ -12,7 +12,7 @@ Install the control package into an Avalonia application:
 dotnet add package HexView
 ```
 
-The current project targets Avalonia `11.3.12`, so keep the host app on a compatible Avalonia line.
+The current project targets Avalonia `12.0.0`, so keep the host app on the same Avalonia line.
 
 ## Namespace
 

--- a/site/global.json
+++ b/site/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.101",
+    "version": "10.0.201",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }

--- a/site/readme.md
+++ b/site/readme.md
@@ -26,7 +26,7 @@ og_type: website
   </a>
   <a class="hv-link-card" href="articles/getting-started/installation">
     <span class="hv-link-card-title"><i class="bi bi-download" aria-hidden="true"></i> Installation</span>
-    <p>Add the package, target Avalonia 11.3, and restore Lunet tooling for docs work.</p>
+    <p>Add the package, target Avalonia 12.0.0, and restore Lunet tooling for docs work.</p>
   </a>
   <a class="hv-link-card" href="articles/getting-started/quickstart-control">
     <span class="hv-link-card-title"><i class="bi bi-window" aria-hidden="true"></i> Quickstart Control</span>

--- a/src/HexView/Controls/HexViewControl.cs
+++ b/src/HexView/Controls/HexViewControl.cs
@@ -302,6 +302,26 @@ public class HexViewControl : Control, ILogicalScrollable
         set => SetValue(BytesWidthProperty, value);
     }
 
+    public bool CanHorizontallyScroll
+    {
+        get => _canHorizontallyScroll;
+        set
+        {
+            _canHorizontallyScroll = value;
+            InvalidateMeasure();
+        }
+    }
+
+    public bool CanVerticallyScroll
+    {
+        get => _canVerticallyScroll;
+        set
+        {
+            _canVerticallyScroll = value;
+            InvalidateMeasure();
+        }
+    }
+
     public IHexFormatter? HexFormatter { get;  set; }
 
     public ILineReader? LineReader { get;  set; }
@@ -518,24 +538,20 @@ public class HexViewControl : Control, ILogicalScrollable
 
     Size IScrollable.Viewport => _viewport;
 
+    bool IScrollable.CanHorizontallyScroll => CanHorizontallyScroll;
+
     bool ILogicalScrollable.CanHorizontallyScroll
     {
-        get => _canHorizontallyScroll;
-        set
-        {
-            _canHorizontallyScroll = value;
-            InvalidateMeasure();
-        }
+        get => CanHorizontallyScroll;
+        set => CanHorizontallyScroll = value;
     }
+
+    bool IScrollable.CanVerticallyScroll => CanVerticallyScroll;
 
     bool ILogicalScrollable.CanVerticallyScroll
     {
-        get => _canVerticallyScroll;
-        set
-        {
-            _canVerticallyScroll = value;
-            InvalidateMeasure();
-        }
+        get => CanVerticallyScroll;
+        set => CanVerticallyScroll = value;
     }
 
     bool ILogicalScrollable.IsLogicalScrollEnabled => true;

--- a/src/HexView/HexView.csproj
+++ b/src/HexView/HexView.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>13</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
@@ -18,12 +18,17 @@
     <PackageProjectUrl>https://github.com/wieslawsoltes/HexView</PackageProjectUrl>
     <PackageId>HexView</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>hexview;control;avalonia;generator</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Upgrade HexView to Avalonia 12.0.0

## Summary

This PR upgrades the HexView repository to the Avalonia `12.0.0` line and aligns the package version with that release.

The change updates shared versioning, SDK resolution, and CI configuration; replaces the removed `Avalonia.Diagnostics` debug package with `ProDiagnostics`; and moves the main `HexView` package from `netstandard2.0` to `net8.0`, which matches the Avalonia 12 baseline.

It also fixes the concrete migration issues that surfaced during the upgrade:

- updates the custom `HexViewControl` scroll implementation for the Avalonia 12 `IScrollable` / `ILogicalScrollable` contract split
- switches the sample storage-provider lookup from the removed visual-root pattern to `TopLevel.GetTopLevel(...)`
- updates sample XAML from deprecated `Watermark` usage to `PlaceholderText`
- moves the hidden sample `CheckBox` event wiring into code-behind so the XAML compiles cleanly on Avalonia 12

During review, I verified that the console sample still restores and builds successfully with the upgraded graph, so it remains part of the solution instead of being excluded.

## Why

Avalonia 12 removes and reshapes several APIs used by this repository:

- `Avalonia.Diagnostics` is no longer the right debug-time package on the Avalonia 12 line
- the scrolling interfaces changed enough to break `HexViewControl`
- the old visual-root access pattern used by the sample app no longer compiles
- the library target framework needed to move off `netstandard2.0`

Without these changes, the solution does not build cleanly against Avalonia `12.0.0`, the package version stays out of sync with the runtime dependency line, and the docs continue to describe the older Avalonia 11-based baseline.

## Impact

- the published `HexView` package now targets `net8.0` and carries version `12.0.0`
- sample projects build cleanly on the upgraded Avalonia 12 graph
- debug builds use `ProDiagnostics` instead of the removed Avalonia diagnostics package
- CI and local SDK resolution now use the installed `.NET 10.0.x` toolchain while still building the `net8.0` / `net9.0` project targets in this repo
- README and site docs now describe the Avalonia 12 baseline instead of the older 11.3.x line

## Validation

I ran the following checks successfully:

- `dotnet build HexView.sln -c Debug`
- `dotnet build HexView.sln -c Release`
- `dotnet build site/api-src/HexView.ApiDocs.csproj -c Release`
- `./build-docs.sh`
- `dotnet pack src/HexView/HexView.csproj -c Release -o artifacts-check`

Additional package-graph verification:

- `dotnet list samples/HexView.Console/HexView.Console.csproj package --include-transitive`
  confirmed that the console sample resolves `Avalonia 12.0.0` transitively on this branch
